### PR TITLE
Support single quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function gulpSassGlobbing () {
   function transform (file, env, callback) {
     var contents = file.contents.toString('utf-8');
 
-    var reg = /@import\s+\"([^\"]*\*[^\"]*)\"/;
+    var reg = /@import\s+[\"']([^\"']*\*[^\"']*)[\"']/;
     var result;
 
     while((result = reg.exec(contents)) !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass-glob",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Gulp task to use glob imports in your sass/scss files.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Allows the use of single quotes

```
@import 'vars/*';
@import 'mixins/*';
@import './views/*';
@import '../components/*';
```