### PR TITLE
re-including main file bug, recursion bug, sass-not-scss bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,31 +4,17 @@ var through = require('through2');
 var glob = require('glob');
 
 function gulpSassGlobbing () {
-  function process (filename) {
-    var replaceString = '';
-
-    if (fs.statSync(filename).isDirectory()) {
-      // Ignore directories start with _
-      if (path.basename(filename).substring(0, 1) == '_') {
-        return '';
-      }
-
-      fs.readdirSync(filename).forEach(function (file) {
-        replaceString += process(filename + path.sep + file);
-      });
-
-      return replaceString;
+  function process (filename, isSass) {
+    if(fs.statSync(filename).isDirectory() || !path.extname(filename).match(/\.sass|\.scss/i)) {
+      return '';
     }
 
-    if (filename.substr(-4).match(/sass|scss/i)) {
-      return '@import "' + filename + '";\n'
-    }
-
-    return '';
+    return '@import "' + filename + '"' + (isSass ? '' : ';') + '\n'
   }
 
   function transform (file, env, callback) {
     var contents = file.contents.toString('utf-8');
+    var isSass = path.extname(file.path) === '.sass';
 
     var reg = /@import\s+\"([^\"]*\*[^\"]*)\"/;
     var result;
@@ -42,7 +28,9 @@ function gulpSassGlobbing () {
       var replaceString = '';
 
       files.forEach(function (filename) {
-        replaceString += process(filename);
+        if(filename !== file.path) {
+          replaceString += process(filename, isSass);
+        }
       });
 
       contents = contents.replace(sub, replaceString);


### PR DESCRIPTION
Maybe it's the way I'm trying to set up my project, but I've found a few wee bugs, which I've attempted to fix.

I have a folder structure like this:

```
src/
    index.sass
    sass/
        common.sass
    components/
        test1/
            index.js
            sass/
                modal.sass
        test2/
            index.js
            other.sass
```

inside `index.sass` i have `@include "**/*"`.

##### re-including main file 
for ages I was getting `File to import not found or unreadable: **/*` errors, until I realised the glob was trying to include the main `index.sass` file again.

##### recursion bug
Say `modal.sass` has:
```
h1
    font-size: 5em
```
as it is 3 folders deep, the resulting css would have:
```
h1{font-size:5em}h1{font-size:5em}h1{font-size:5em}
```

##### sass can't have semi-colons
just a little thing, as the code actually works without this, but `.sass` files shouldn't have semi-colon's at the end of lines.

##### removing directories starting with `_`
i couldn't figure out a nice way to add your functionality to ignore these folders again.. although i'd recommend changing to folders starting with a `.` instead, as glob will ignore these out of the box.

I've not made a pull request before, so please let me know if I've messed anything up and I'll attempt to fix it.

Cheers.