### PR TITLE
Allow matching patterns not ending with * or *.s(a/c)ss

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default function gulpSassGlob () {
 }
 
 function transform (file, env, callback) {
-  const reg = /^\s*@import\s+["']([^"']+\*(\.scss|\.sass)?)["'];?$/gm
+  const reg = /^\s*@import\s+["']([^"']+\*[^"']*(\.scss|\.sass)?)["'];?$/gm
   const isSass = path.extname(file.path) === '.sass'
   const base = path.normalize(path.join(path.dirname(file.path), '/'))
 

--- a/test/test-scss/fixed-name.scss
+++ b/test/test-scss/fixed-name.scss
@@ -1,0 +1,1 @@
+@import "recursive/**/_f3.scss";

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,21 @@ describe('gulp-sass-glob', () => {
       .on('end', done)
   })
 
+  it('(sass) should understand imports with fixed file name', (done) => {
+    const expectedResult = [
+      '@import "recursive/nested/_f3.scss";'
+    ].join('\n')
+
+    vinyl
+      .src(path.join(__dirname, '/test-scss/fixed-name.scss'))
+      .pipe(sassGlob())
+      .on('data', (file) => {
+        const contents = file.contents.toString('utf-8').trim()
+        expect(contents).to.equal(expectedResult.trim())
+      })
+      .on('end', done)
+  })
+
   it('(scss) should parse a directory recursively', (done) => {
     const expectedResult = [
       '@import "recursive/_f1.scss";',


### PR DESCRIPTION
It's actually  a regression fix.
I tried updating from 0.0.8 to 1.0.6 and I found out that some of my files don't compile.

The refinement in the regular expression is to blame: before it didn't require the asterisk to be the last character before the ampersand or quotation mark:

([index.js#L19 @ 0.0.8](https://github.com/tomgrooffer/gulp-sass-glob/blob/5e997db153ff47e06861e5717f6a336a531794ab/index.js#L19))
```js
// from 0.0.8
var reg = /@import\s+[\"']([^\"']*\*[^\"']*)[\"']/;
```

and [on 1.0.6](https://github.com/tomgrooffer/gulp-sass-glob/blob/6dfff52bd06081ae67b8f9e1301c2f5b70f5d5f1/src/index.js#L12) it does:

```js
  const reg = /^\s*@import\s+["']([^"']+\*(\.scss|\.sass)?)["'];?$/gm
```

Nothing but either `.scss` or `.sass` may occur after the last asterisk which disallows imports like `@import "/foo/bar/**/someFixedFileName.scss";`
I suggest those imports should be brought back since this is a valid glob pattern.

This is a solution that covers this particular case. I'm sure it doesn't cover many other glob patterns `glob` can resolve (for example alternative groups).

We can go for [jonschlinkert/is-glob](https://github.com/jonschlinkert/is-glob) instead and do it the proper way but it requires adding a new dependency to the project.