### PR TITLE
WIP: fix problems with stateful regular expression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,11 @@ function transform (file, env, callback) {
     const replaceString = imports.join('\n')
     contents = contents.replace(importRule, replaceString)
     file.contents = new Buffer(contents)
+    // Since we change a part of the `contents` being matched and some parts
+    // previously matched are not already there we have to reset the regular
+    // expression state. It would be better to split a file into lines and
+    // match each one with a stateless (non-global) expression
+    reg.lastIndex = 0;
   }
 
   callback(null, file)

--- a/src/index.js
+++ b/src/index.js
@@ -37,12 +37,14 @@ function transform (file, env, callback) {
 
     const replaceString = imports.join('\n')
     contents = contents.replace(importRule, replaceString)
+    // `reg.lastIndex` indicates the last character of the `contents` when `reg`
+    // matched. Since we remove this line we have to rewind the index to make
+    // it go though all characters of the added lines. If it's not done then
+    // a false positive of `reg.exec(contents) == null` occurs before all lines
+    // of the file are processed because `reg` starts from somewhere in the
+    // middle of last `replaceString` instead of the very beginning of it.
+    reg.lastIndex -= importRule.length;
     file.contents = new Buffer(contents)
-    // Since we change a part of the `contents` being matched and some parts
-    // previously matched are not already there we have to reset the regular
-    // expression state. It would be better to split a file into lines and
-    // match each one with a stateless (non-global) expression
-    reg.lastIndex = 0;
   }
 
   callback(null, file)


### PR DESCRIPTION
Actually I need some help with testing that fix.

In my project (sadly it's a private repository and I can't share all of it) I use `0.0.8` and it works.
I tried to update to `1.0.6` which is the current `latest` but I failed for 2 reasons. The first I managed to detect, fix and test (#19) but the second one seems harder to test.

My root scss file is:

``` scss
@import "colors";
@import "variables";
@import "../js/packages/**/_variables.scss";

@import "../../www/lib/ionic/scss/ionic";

@import "fonts";
@import "type";
@import "icons";
@import "items";
@import "mixins";
@import "transitions";

@import "../js/packages/**/_module.scss";
@import "../js/packages/**/directives/**/*";
@import "../js/packages/**/forms/**/*";
@import "../js/packages/**/modals/**/*";
@import "../js/packages/**/popovers/**/*";

@import "templates/*";
@import "platforms/*";
```

after applying the fix from #19 it still fails to compile on line `@import "templates/*";`
I know it's because of [the `g` flag in the regex](https://github.com/tomgrooffer/gulp-sass-glob/blob/6dfff52bd06081ae67b8f9e1301c2f5b70f5d5f1/src/index.js#L12) but I can't create a test that will reproduce my case
