### PR TITLE
Fix empty directory bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-dist
 *.log
 .DS_Store

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,79 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = gulpSassGlob;
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+var _through = require('through2');
+
+var _through2 = _interopRequireDefault(_through);
+
+var _glob = require('glob');
+
+var _glob2 = _interopRequireDefault(_glob);
+
+var _slash = require('slash');
+
+var _slash2 = _interopRequireDefault(_slash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function gulpSassGlob() {
+  return _through2.default.obj(transform);
+}
+
+function transform(file, env, callback) {
+  var reg = /^\s*@import\s+["']([^"']+\*(\.scss|\.sass)?)["'];?$/gm;
+  var isSass = _path2.default.extname(file.path) === '.sass';
+  var base = _path2.default.normalize(_path2.default.join(_path2.default.dirname(file.path), '/'));
+
+  var contents = file.contents.toString('utf-8');
+  var contentsCount = contents.split('\n').length;
+
+  var result = void 0;
+
+  for (var i = 0; i < contentsCount; i++) {
+    result = reg.exec(contents);
+
+    if (result !== null) {
+      (function () {
+        var importRule = result[0];
+        var globPattern = result[1];
+
+        var files = _glob2.default.sync(_path2.default.join(base, globPattern), {
+          cwd: base
+        });
+
+        var imports = [];
+
+        files.forEach(function (filename) {
+          if (filename !== file.path && isSassOrScss(filename)) {
+            // remove parent base path
+            filename = _path2.default.normalize(filename).replace(base, '');
+            imports.push('@import "' + (0, _slash2.default)(filename) + '"' + (isSass ? '' : ';'));
+          }
+        });
+
+        var replaceString = imports.join('\n');
+        contents = contents.replace(importRule, replaceString);
+        file.contents = new Buffer(contents);
+      })();
+    }
+  }
+
+  callback(null, file);
+}
+
+function isSassOrScss(filename) {
+  return !_fs2.default.statSync(filename).isDirectory() && _path2.default.extname(filename).match(/\.sass|\.scss/i);
+}
+module.exports = exports['default'];

--- a/src/index.js
+++ b/src/index.js
@@ -14,30 +14,35 @@ function transform (file, env, callback) {
   const base = path.normalize(path.join(path.dirname(file.path), '/'))
 
   let contents = file.contents.toString('utf-8')
+  let contentsCount = contents.split('\n').length
 
   let result
 
-  while ((result = reg.exec(contents)) !== null) {
-    const importRule = result[0]
-    const globPattern = result[1]
+  for(var i=0; i<contentsCount; i++) {
+    result = reg.exec(contents)
 
-    const files = glob.sync(path.join(base, globPattern), {
-      cwd: base
-    })
+    if(result !== null) {
+      const importRule = result[0]
+      const globPattern = result[1]
 
-    let imports = []
+      const files = glob.sync(path.join(base, globPattern), {
+        cwd: base
+      })
 
-    files.forEach((filename) => {
-      if (filename !== file.path && isSassOrScss(filename)) {
-        // remove parent base path
-        filename = path.normalize(filename).replace(base, '')
-        imports.push('@import "' + slash(filename) + '"' + (isSass ? '' : ';'))
-      }
-    })
+      let imports = []
 
-    const replaceString = imports.join('\n')
-    contents = contents.replace(importRule, replaceString)
-    file.contents = new Buffer(contents)
+      files.forEach((filename) => {
+        if (filename !== file.path && isSassOrScss(filename)) {
+          // remove parent base path
+          filename = path.normalize(filename).replace(base, '')
+          imports.push('@import "' + slash(filename) + '"' + (isSass ? '' : ';'))
+        }
+      })
+
+      const replaceString = imports.join('\n')
+      contents = contents.replace(importRule, replaceString)
+      file.contents = new Buffer(contents)
+    }
   }
 
   callback(null, file)

--- a/test/test-scss/ignore-empty.scss
+++ b/test/test-scss/ignore-empty.scss
@@ -1,0 +1,2 @@
+@import "empty/**/*.scss";
+@import "import/*";

--- a/test/test.js
+++ b/test/test.js
@@ -84,4 +84,20 @@ describe('gulp-sass-glob', () => {
       })
       .on('end', done)
   })
+
+  it('(scss) should ignore empty directories', (done) => {
+    const expectedResult = [
+      '@import "import/_f1.scss";',
+      '@import "import/_f2.scss";'
+    ].join('\n')
+
+    vinyl
+      .src(path.join(__dirname, '/test-scss/ignore-empty.scss'))
+      .pipe(sassGlob())
+      .on('data', (file) => {
+        const contents = file.contents.toString('utf-8').trim()
+        expect(contents).to.equal(expectedResult.trim())
+      })
+      .on('end', done)
+  })
 })


### PR DESCRIPTION
Basically, changed the `while` loop to a `for` loop.

The `while` loop was exiting on the first empty directory it found, causing subsequent `@import` rules to use native CSS `@import`.
