### PR TITLE
Compile ES2015 code and bump to version 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ main.scss
 @import "generic/**/*.scss";
 @import "../components/**/*.scss";
 @import "../views/**/*.scss";
+@import "../views/**/*something.scss";
+@import "../views/**/all.scss";
 ```
 
 *NOTE*: Also support using `'` (single quotes) for example: `@import 'vars/**/*.scss';`

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ![dependencies](https://david-dm.org/DanielaValero/gulp-sass-glob.svg)
 
-# gulp-sass-glob-2
+# About gulp-sass-glob-2
 
-This is a fork of [gulp-sass-glob](https://www.npmjs.com/package/gulp-sass-glob). It is meant to be a temporal package, so the users of the last pull requests can get the package directly from NPM until the author of the plugin has time to publish the new version that contains all of them.
+This is a fork of [gulp-sass-glob](https://www.npmjs.com/package/gulp-sass-glob). It is **meant to be a temporal package**, so the users of the last pull requests can get the package directly from NPM until the author of the plugin has time to publish the new version that contains all of them.
 
 Once we have the last version published, we will request NPM to remove this package, we love to contribute to open source, while joining forces to have one strong solution, rather than multiple weak.
+
+# Overview
 
 [Gulp](http://gulpjs.com/) plugin for [gulp-sass](https://github.com/dlmanning/gulp-sass) to use glob imports.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-[![Package Quality](http://npm.packagequality.com/badge/gulp-sass-glob.png)](http://packagequality.com/#?package=gulp-sass-glob)
+[![Package Quality](http://npm.packagequality.com/badge/gulp-sass-glob-2.png)](http://packagequality.com/#?package=gulp-sass-glob-2)
 
-[![Package Quality](http://npm.packagequality.com/shield/gulp-sass-glob.svg)](http://packagequality.com/#?package=gulp-sass-glob)
+[![Package Quality](http://npm.packagequality.com/shield/gulp-sass-glob-2.svg)](http://packagequality.com/#?package=gulp-sass-glob-2)
 
-# gulp-sass-glob
+![dependencies](https://david-dm.org/DanielaValero/gulp-sass-glob.svg)
+
+# gulp-sass-glob-2
+
+This is a fork of [gulp-sass-glob](https://www.npmjs.com/package/gulp-sass-glob). It is meant to be a temporal package, so the users of the last pull requests can get the package directly from NPM until the author of the plugin has time to publish the new version that contains all of them.
+
+Once we have the last version published, we will request NPM to remove this package, we love to contribute to open source, while joining forces to have one strong solution, rather than multiple weak.
 
 [Gulp](http://gulpjs.com/) plugin for [gulp-sass](https://github.com/dlmanning/gulp-sass) to use glob imports.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,7 +32,7 @@ function gulpSassGlob() {
 }
 
 function transform(file, env, callback) {
-  var reg = /^\s*@import\s+["']([^"']+\*(\.scss|\.sass)?)["'];?$/gm;
+  var reg = /^\s*@import\s+["']([^"']+\*[^"']*(\.scss|\.sass)?)["'];?$/gm;
   var isSass = _path2.default.extname(file.path) === '.sass';
   var base = _path2.default.normalize(_path2.default.join(_path2.default.dirname(file.path), '/'));
 

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.4",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^2.2.0",
+    "eslint": "^2.12.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-promise": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp task to use glob imports in your sass/scss files.",
   "repository": {
     "type": "git",
-    "url": "git+https://tomgrooffer@github.com/tomgrooffer/gulp-sass-glob.git"
+    "url": "git+https://github.com/DanielaValero/gulp-sass-glob.git"
   },
   "keywords": [
     "gulp",
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/tomgrooffer/gulp-sass-glob/issues"
   },
-  "homepage": "https://github.com/tomgrooffer/gulp-sass-glob#readme",
+  "homepage": "https://github.com/DanielaValero/gulp-sass-glob#readme",
   "main": "./dist/index.js",
   "scripts": {
     "compile": "babel -d dist/ src/",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-sass-glob",
+  "name": "gulp-sass-glob-2",
   "version": "1.0.8",
   "description": "Gulp task to use glob imports in your sass/scss files.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass-glob",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Gulp task to use glob imports in your sass/scss files.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello,

I am making this pull request which:

* Fixes some dependencies problems there were with babel-eslint and eslint
* Compiles ES2015 code to ES5
* Bumps to version 1.0.8.

With this, we can install the code merged in the latests pull requests via git, until the new version is published to npm

Fixes #23 
