### PR TITLE
Allow ignoring files that match glob pattern(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ gulp.task('styles', function () {
 });
 ```
 
+# Ignoring files and directories by pattern
+
+You can optionally provide an array of paths to be ignored. Any files and directories that match any of these glob patterns are skipped.
+
+```
+gulp.task('styles', function () {
+    return gulp
+        .src('src/styles/main.scss')
+          .pipe(sassGlob({
+              ignorePaths: [
+                  '**/_f1.scss',
+                  'recursive/*.scss',
+                  'import/**'
+              ]
+          }))
+        .pipe(sass())
+        .pipe(gulp.dest('dist/styles'));
+});
+```
+
 # Troubleshooting
 
 ## Nested glob imports

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,11 +28,15 @@ var _slash = require('slash');
 
 var _slash2 = _interopRequireDefault(_slash);
 
+var _minimatch = require('minimatch');
+
+var _minimatch2 = _interopRequireDefault(_minimatch);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
-var IMPORT_RE = /^([ \t]*(?:\/\*.*)?)@import\s+["']([^"']+\*[^"']*(?:\.scss|\.sass)?)["'];?([ \t]*(?:\/[\/\*].*)?)$/gm;
+var IMPORT_RE = /^([ \t]*(?:\/\*.*)?)@import\s+["']([^"']+\*[^"']*(?:\.scss|\.sass)?)["'];?([ \t]*(?:\/[/*].*)?)$/gm;
 
 function gulpSassGlob() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
@@ -57,6 +61,7 @@ function transform(file, env, callback) {
 
   var isSass = _path2.default.extname(file.path) === '.sass';
   var base = _path2.default.normalize(_path2.default.join(_path2.default.dirname(file.path), '/'));
+  var ignorePaths = options.ignorePaths || [];
 
   var searchBases = [base].concat(_toConsumableArray(includePaths));
   var contents = file.contents.toString('utf-8');
@@ -96,7 +101,12 @@ function transform(file, env, callback) {
           if (filename !== file.path && isSassOrScss(filename)) {
             // remove parent base path
             filename = _path2.default.normalize(filename).replace(basePath, '');
-            imports.push('@import "' + (0, _slash2.default)(filename) + '"' + (isSass ? '' : ';'));
+            if (!ignorePaths.some(function (ignorePath) {
+              return (0, _minimatch2.default)(filename, ignorePath);
+            })) {
+              // remove parent base path
+              imports.push('@import "' + (0, _slash2.default)(filename) + '"' + (isSass ? '' : ';'));
+            }
           }
         });
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "glob": "^7.1.1",
+    "minimatch": "^3.0.3",
     "slash": "^1.0.0",
     "through2": "^2.0.3"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,72 @@ describe('gulp-sass-glob', () => {
             .on('end', done);
   });
 
+  it('(scss) should omit ignored directories', (done) => {
+      const expectedResult = [
+          '@import "recursive/_f1.scss";',
+          '@import "recursive/_f2.scss";',
+          '@import "import/_f1.scss";',
+          '@import "import/_f2.scss";'
+      ].join('\n')
+
+      vinyl
+          .src(path.join(__dirname, '/test-scss/multiple.scss'))
+          .pipe(sassGlob({
+              ignorePaths: [
+                  'recursive/nested/**'
+              ]
+          }))
+          .on('data', (file) => {
+              const contents = file.contents.toString('utf-8').trim()
+              expect(contents).to.equal(expectedResult.trim())
+          })
+          .on('end', done)
+  })
+
+
+  it('(scss) should allow globbing when ignoring files', (done) => {
+      const expectedResult = [
+          '@import "recursive/_f2.scss";',
+          '@import "recursive/nested/_f3.scss";',
+          '@import "import/_f2.scss";'
+      ].join('\n')
+
+      vinyl
+          .src(path.join(__dirname, '/test-scss/multiple.scss'))
+          .pipe(sassGlob({
+              ignorePaths: [
+                  '**/_f1.scss'
+              ]
+          }))
+          .on('data', (file) => {
+              const contents = file.contents.toString('utf-8').trim()
+              expect(contents).to.equal(expectedResult.trim())
+          })
+          .on('end', done)
+  })
+
+  it('(scss) should allow multiple ignore patterns', (done) => {
+      const expectedResult = [
+          '@import "recursive/nested/_f3.scss";',
+      ].join('\n')
+
+      vinyl
+          .src(path.join(__dirname, '/test-scss/multiple.scss'))
+          .pipe(sassGlob({
+              ignorePaths: [
+                  '**/_f1.scss',
+                  'recursive/_f2.scss',
+                  'import/**'
+              ]
+          }))
+          .on('data', (file) => {
+              const contents = file.contents.toString('utf-8').trim()
+              expect(contents).to.equal(expectedResult.trim())
+          })
+          .on('end', done)
+  })
+
+
   it('(scss) should ignore commented globs', (done) => {
     vinyl
             .src(path.join(__dirname, '/test-scss/ignore-comments.scss'))


### PR DESCRIPTION
This commit allows passing the option `ignorePaths` which should contain an array of strings. These will be tested against any imported files using `minimatch` (the library that `glob` uses for glob matching) and if they match the file(s) will be omitted. Three new tests included.
